### PR TITLE
Use map and collect to implement logic

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Vanessa McHale vamchale@gmail.com"]
 [dependencies]
 num-bigint = "0.1"
 num-traits = "0.1"
+rand = "0.3"
 
 [profile.release]
 lto = true

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate num_bigint;
 extern crate num_traits;
+extern crate rand;
 
 pub use functions::*;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -96,25 +96,25 @@ pub mod functions {
         (1..v.len()).map(|i| v.get(i..).unwrap().to_owned()).collect()
     }
 
-    struct Fib {
-        curr: i32,
-        next: i32,
-    }
+    // struct Fib {
+    //     curr: i32,
+    //     next: i32,
+    // }
 
-    impl Iterator for Fib {
-        type Item = i32;
-        fn next(&mut self) -> Option<i32> {
-            let new_next = self.curr + self.next;
-            let new_curr = replace(&mut self.next, new_next);
-            Some(replace(&mut self.curr, new_curr))
-        }
-    }
+    // impl Iterator for Fib {
+    //     type Item = i32;
+    //     fn next(&mut self) -> Option<i32> {
+    //         let new_next = self.curr + self.next;
+    //         let new_curr = replace(&mut self.next, new_next);
+    //         Some(replace(&mut self.curr, new_curr))
+    //     }
+    // }
 
-    impl Fib {
-        fn new() -> Fib {
-            Fib { curr: 1, next: 1 }
-        }
-    }
+    // impl Fib {
+    //     fn new() -> Fib {
+    //         Fib { curr: 1, next: 1 }
+    //     }
+    // }
 
     /// this function computes the fibonacci sequence iteratively
     ///
@@ -126,9 +126,10 @@ pub mod functions {
     /// assert_eq!(89, fib_iterative(10))
     /// ```
     pub fn fib_iterative(n: usize) -> i32 {
-        let fib = Fib::new();
-        let v: Vec<i32> = fib.take(n + 1).collect();
-        v[n]
+        (0..n).fold((0,1), |curr,_| (curr.1, curr.0+curr.1)).1
+        // let fib = Fib::new();
+        // let v: Vec<i32> = fib.take(n + 1).collect();
+        // v[n]
     }
 
     /// this function computes the fibonacci sequence iteratively, to arbitrary precision

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,21 +30,39 @@ pub mod functions {
     /// assert_eq!(v, suffix_vec(s))
     /// ```
     pub fn suffix_vec(s: &str) -> Vec<String> {
-        s.char_indices()
-            .skip(1)
-            .map(|(j, _)| (&s[j..]).to_string())
+        let mut i = 0;
+        (1..s.len())
+            .map(|_| {
+                     while !s.is_char_boundary(i) {
+                         i += 1;
+                     }
+                     (&s[i..]).to_string()
+                 })
             .collect()
     }
 
     pub fn suffix_vec_cow(s: &str) -> Vec<Cow<str>> {
-        s.char_indices()
-            .skip(1)
-            .map(|(j, _)| Cow::from(&s[j..]))
+        let mut i = 0;
+        (1..s.len())
+            .map(|_| {
+                     while !s.is_char_boundary(i) {
+                         i += 1;
+                     }
+                     Cow::from(&s[i..])
+                 })
             .collect()
     }
 
     pub fn suffix_vec_ref(s: &str) -> Vec<&str> {
-        s.char_indices().skip(1).map(|(j, _)| &s[j..]).collect()
+        let mut i = 0;
+        (1..s.len())
+            .map(|_| {
+                     while !s.is_char_boundary(i) {
+                         i += 1;
+                     }
+                     &s[i..]
+                 })
+            .collect()
     }
 
     /// generic version of the above function

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,28 +30,21 @@ pub mod functions {
     /// assert_eq!(v, suffix_vec(s))
     /// ```
     pub fn suffix_vec(s: &str) -> Vec<String> {
-        //let mut vec = Vec::with_capacity(s.char_indices().count());// Vec::new();
-        let mut vec = Vec::new(); //with_capacity(s.char_indices().count());// Vec::new();
-        for (j, _) in s.char_indices().skip(1) {
-            vec.push((&s[j..]).to_string());
-        }
-        vec
+        s.char_indices()
+            .skip(1)
+            .map(|x| (&s[(x.0)..]).to_string())
+            .collect()
     }
 
     pub fn suffix_vec_cow(s: &str) -> Vec<Cow<str>> {
-        let mut vec = Vec::new();
-        for (j, _) in s.char_indices().skip(1) {
-            vec.push(Cow::from(&s[j..]));
-        }
-        vec
+        s.char_indices()
+            .skip(1)
+            .map(|x| Cow::from(&s[(x.0)..]))
+            .collect()
     }
 
     pub fn suffix_vec_ref(s: &str) -> Vec<&str> {
-        let mut vec = Vec::new();
-        for (j, _) in s.char_indices().skip(1) {
-            vec.push(&s[j..]);
-        }
-        vec
+        s.char_indices().skip(1).map(|x| &s[(x.0)..]).collect()
     }
 
     /// generic version of the above function

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -93,12 +93,7 @@ pub mod functions {
     /// assert_eq!(suffix_iter(&v), result)
     /// ```
     pub fn suffix_iter<T: Clone>(v: &Vec<T>) -> Vec<Vec<T>> {
-        let mut vec = Vec::new();
-        let l = v.len();
-        for i in 1..l {
-            vec.push(v.get(i..).unwrap().to_owned());
-        }
-        vec
+        (1..v.len()).map(|i| v.get(i..).unwrap().to_owned()).collect()
     }
 
     struct Fib {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,39 +30,21 @@ pub mod functions {
     /// assert_eq!(v, suffix_vec(s))
     /// ```
     pub fn suffix_vec(s: &str) -> Vec<String> {
-        let mut i = 0;
-        (1..s.len())
-            .map(|_| {
-                     while !s.is_char_boundary(i) {
-                         i += 1;
-                     }
-                     (&s[i..]).to_string()
-                 })
+        s.char_indices()
+            .skip(1)
+            .map(|(j, _)| (&s[j..]).to_string())
             .collect()
     }
 
     pub fn suffix_vec_cow(s: &str) -> Vec<Cow<str>> {
-        let mut i = 0;
-        (1..s.len())
-            .map(|_| {
-                     while !s.is_char_boundary(i) {
-                         i += 1;
-                     }
-                     Cow::from(&s[i..])
-                 })
+        s.char_indices()
+            .skip(1)
+            .map(|(j, _)| Cow::from(&s[j..]))
             .collect()
     }
 
     pub fn suffix_vec_ref(s: &str) -> Vec<&str> {
-        let mut i = 0;
-        (1..s.len())
-            .map(|_| {
-                     while !s.is_char_boundary(i) {
-                         i += 1;
-                     }
-                     &s[i..]
-                 })
-            .collect()
+        s.char_indices().skip(1).map(|(j, _)| &s[j..]).collect()
     }
 
     /// generic version of the above function

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,21 +30,54 @@ pub mod functions {
     /// assert_eq!(v, suffix_vec(s))
     /// ```
     pub fn suffix_vec(s: &str) -> Vec<String> {
-        s.char_indices()
-            .skip(1)
-            .map(|(j, _)| (&s[j..]).to_string())
-            .collect()
+        let len = s.len();
+        let mut vec = Vec::with_capacity(len);
+        let mut i = 1;
+        'outer: while i < len {
+            while !s.is_char_boundary(i) {
+                i += 1;
+                if i >= len {
+                    break 'outer;
+                }
+            }
+            i += 1;
+            vec.push((&s[i - 1..]).to_string());
+        }
+        vec
     }
 
     pub fn suffix_vec_cow(s: &str) -> Vec<Cow<str>> {
-        s.char_indices()
-            .skip(1)
-            .map(|(j, _)| Cow::from(&s[j..]))
-            .collect()
+        let len = s.len();
+        let mut vec = Vec::with_capacity(len);
+        let mut i = 1;
+        'outer: while i < len {
+            while !s.is_char_boundary(i) {
+                i += 1;
+                if i >= len {
+                    break 'outer;
+                }
+            }
+            i += 1;
+            vec.push(Cow::from(&s[i - 1..]));
+        }
+        vec
     }
 
     pub fn suffix_vec_ref(s: &str) -> Vec<&str> {
-        s.char_indices().skip(1).map(|(j, _)| &s[j..]).collect()
+        let len = s.len();
+        let mut vec = Vec::with_capacity(len);
+        let mut i = 1;
+        'outer: while i < len {
+            while !s.is_char_boundary(i) {
+                i += 1;
+                if i >= len {
+                    break 'outer;
+                }
+            }
+            i += 1;
+            vec.push(&s[i - 1..]);
+        }
+        vec
     }
 
     /// generic version of the above function

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,19 +32,19 @@ pub mod functions {
     pub fn suffix_vec(s: &str) -> Vec<String> {
         s.char_indices()
             .skip(1)
-            .map(|x| (&s[(x.0)..]).to_string())
+            .map(|(j, _)| (&s[j..]).to_string())
             .collect()
     }
 
     pub fn suffix_vec_cow(s: &str) -> Vec<Cow<str>> {
         s.char_indices()
             .skip(1)
-            .map(|x| Cow::from(&s[(x.0)..]))
+            .map(|(j, _)| Cow::from(&s[j..]))
             .collect()
     }
 
     pub fn suffix_vec_ref(s: &str) -> Vec<&str> {
-        s.char_indices().skip(1).map(|x| &s[(x.0)..]).collect()
+        s.char_indices().skip(1).map(|(j, _)| &s[j..]).collect()
     }
 
     /// generic version of the above function

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -3,6 +3,11 @@
 #![allow(unused_imports)]
 extern crate test;
 
+extern crate rand;
+
+use rand::Rng;
+use rand::distributions::{IndependentSample, Range};
+
 use std::iter;
 use std::mem::replace;
 use test::test::Bencher;
@@ -119,7 +124,10 @@ fn bench_suffix_extra_long_generic(b: &mut Bencher) {
 // this one doesn't need any special considerations
 #[bench]
 fn bench_iterative_fib(b: &mut Bencher) {
-    b.iter(|| fib_iterative(15))
+    let between = Range::new(6, 7);
+    let mut rng = rand::thread_rng();
+    let val = between.ind_sample(&mut rng);
+    b.iter(|| fib_iterative(val))
 }
 
 // for comparison to Haskell.


### PR DESCRIPTION
Your implementation in Rust is not optimal (I don't know if mine is, but it is better than yours).
Just today I did some benchmarks about pushing to a vector in a loop vs using the `map` and `collect` methods. Since `Vec` gets resized when being pushed into, it is really slow if the vector is initialized using `new()`. Using `Vec::with_capacity()` would be better but it is still slightly slower than using map and collect.
Currently I do not have the tools installed to run all benchmarks but maybe you can merge my changes and rerun the benches.

PS: The benchmarks to compare for loops against map/collect looked like this:
```Rust
pub fn xor_encryption<T>(data: &[T], key: &[T]) -> Vec<<T as ops::BitXor>::Output>
where
    T: ops::BitXor + Copy,
{
    data.iter()
        .zip(key.iter().cycle())
        .map(|it| *it.0 ^ *it.1)
        .collect()
}

fn xor_encryption_for<T>(data: &[T], key: &[T]) -> Vec<<T as ops::BitXor>::Output>
where
    T: ops::BitXor + Copy,
{
    let mut result = Vec::new();
    for it in data.iter().zip(key.iter().cycle()) {
        result.push(*it.0 ^ *it.1)
    }
    result
}

fn xor_encryption_for_capacity<T>(data: &[T], key: &[T]) -> Vec<<T as ops::BitXor>::Output>
where
    T: ops::BitXor + Copy,
{
    let mut result = Vec::with_capacity(data.len());
    for it in data.iter().zip(key.iter().cycle()) {
        result.push(*it.0 ^ *it.1)
    }
    result
}
```
and the results look something like this:
```
test tests::bench_xor_for          ... bench:         176 ns/iter (+/- 0)
test tests::bench_xor_for_capacity ... bench:         136 ns/iter (+/- 0)
test tests::bench_xor_map          ... bench:         133 ns/iter (+/- 0)
```